### PR TITLE
Update Makefile.in to also remove the library symlink during clean

### DIFF
--- a/libsndio/Makefile.in
+++ b/libsndio/Makefile.in
@@ -108,7 +108,7 @@ uninstall:
 		cd ${DESTDIR}${MAN7_DIR} && rm -f ${MAN7}
 
 clean:
-		rm -f -- ${SO} ${SO_LINK} *.o
+		rm -f -- ${SO} ${SO_LINK} ${SO_LINK_MAJ} *.o
 
 # ---------------------------------------------------------- dependencies ---
 


### PR DESCRIPTION
During make clean, a libsndio/libsndio.so.7 symlink was leftover .