### PR TITLE
configure: define HAVE_GETPEEREID to fix a build failure on GNU/Hurd …

### DIFF
--- a/configure
+++ b/configure
@@ -75,7 +75,8 @@ case `uname` in
 		user=sndiod
 		so_ldflags="-Wl,-soname=libsndio.so.\${MAJ}"
 		so_link="libsndio.so libsndio.so.\${MAJ} libsndio.so.\${MAJ}.0"
-		defs='-D_GNU_SOURCE -DHAVE_SOCK_CLOEXEC -DHAVE_CLOCK_GETTIME'
+		defs='-D_GNU_SOURCE -DHAVE_SOCK_CLOEXEC -DHAVE_CLOCK_GETTIME \\\
+		-DHAVE_GETPEEREID'
 		;;
 	GNU) # No output support on Hurd, but otherwise like linux
 		oss=no
@@ -83,7 +84,8 @@ case `uname` in
 		user=sndiod
 		so_ldflags="-Wl,-soname=libsndio.so.\${MAJ}"
 		so_link="libsndio.so libsndio.so.\${MAJ} libsndio.so.\${MAJ}.0"
-		defs='-D_GNU_SOURCE -DHAVE_SOCK_CLOEXEC -DHAVE_CLOCK_GETTIME'
+		defs='-D_GNU_SOURCE -DHAVE_SOCK_CLOEXEC -DHAVE_CLOCK_GETTIME \\\
+		-DHAVE_GETPEEREID'
 		;;
 	NetBSD)
 		sun=no


### PR DESCRIPTION
…and Kfreebsd

i686-gnu-gcc -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I../bsd-compat -DDEBUG -D_GNU_SOURCE -DHAVE_SOCK_CLOEXEC -DHAVE_CLOCK_GETTIME -DUSE_LIBBSD -DHAVE_STRLCPY -DHAVE_STRLCAT -DHAVE_STRTONUM -c -o getpeereid.o ../bsd-compat/getpeereid.c ../bsd-compat/getpeereid.c: In function ‘_sndio_getpeereid’: ../bsd-compat/getpeereid.c:24:22: error: storage size of ‘cr’ isn’t known
   24 |         struct ucred cr;
      |                      ^~
../bsd-compat/getpeereid.c:27:39: error: ‘SO_PEERCRED’ undeclared (first use in this function)
   27 |         if (getsockopt(s, SOL_SOCKET, SO_PEERCRED, &cr, &len) < 0)
      |                                       ^~~~~~~~~~~
../bsd-compat/getpeereid.c:27:39: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [Makefile:134: getpeereid.o] Error 1